### PR TITLE
fix(ngResources): support IPv6 URLs

### DIFF
--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -348,6 +348,7 @@ function shallowClearAndCopy(src, dst) {
  */
 angular.module('ngResource', ['ng']).
   provider('$resource', function() {
+    var PROTOCOL_AND_DOMAIN_REGEX = /^https?:\/\/[^\/]*/;
     var provider = this;
 
     this.defaults = {
@@ -422,7 +423,8 @@ angular.module('ngResource', ['ng']).
           var self = this,
             url = actionUrl || self.template,
             val,
-            encodedVal;
+            encodedVal,
+            protocolAndDomain = '';
 
           var urlParams = self.urlParams = {};
           forEach(url.split(/\W/), function(param) {
@@ -435,6 +437,10 @@ angular.module('ngResource', ['ng']).
             }
           });
           url = url.replace(/\\:/g, ':');
+          url = url.replace(PROTOCOL_AND_DOMAIN_REGEX, function(match) {
+            protocolAndDomain = match;
+            return '';
+          });
 
           params = params || {};
           forEach(self.urlParams, function(_, urlParam) {
@@ -465,7 +471,7 @@ angular.module('ngResource', ['ng']).
           // E.g. `http://url.com/id./format?q=x` becomes `http://url.com/id.format?q=x`
           url = url.replace(/\/\.(?=\w+($|\?))/, '.');
           // replace escaped `/\.` with `/.`
-          config.url = url.replace(/\/\\\./, '/.');
+          config.url = protocolAndDomain + url.replace(/\/\\\./, '/.');
 
 
           // set params - delegate param encoding to $http

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -297,6 +297,14 @@ describe("resource", function() {
     R.get({a: 'foo'});
   });
 
+  it('should support IPv6 URLs', function() {
+    var R = $resource('http://[2620:0:861:ed1a::1]/:ed1a/', {}, {}, {stripTrailingSlashes: false});
+    $httpBackend.expect('GET', 'http://[2620:0:861:ed1a::1]/foo/').respond({});
+    $httpBackend.expect('GET', 'http://[2620:0:861:ed1a::1]/').respond({});
+    R.get({ed1a: 'foo'});
+    R.get({});
+  });
+
   it('should support overriding provider default trailing-slash stripping configuration', function() {
     // Set the new behavior for all new resources created by overriding the
     // provider configuration


### PR DESCRIPTION
Do not confuse IPv6 URLs domains and resource parameters.

Closes #12512
Closes #12532